### PR TITLE
Use peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,11 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "ajv": "^4.11.6",
-    "ajv-pack": "^0.2.7",
     "loader-utils": "^1.0.3"
+  },
+  "peerDependencies": {
+    "ajv": "*",
+    "ajv-pack": "*"
   },
   "devDependencies": {
     "ava": "^0.19.1",


### PR DESCRIPTION
This will allow consumers to select the ajv version they would like to use